### PR TITLE
Use gate label in label of gate's inverse

### DIFF
--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -327,7 +327,8 @@ class Instruction:
         else:
             inverse_gate = Gate(name=self.name + '_dg',
                                 num_qubits=self.num_qubits,
-                                params=self.params.copy())
+                                params=self.params.copy(),
+                                label=self.label+'_dg')
 
         inverse_gate.definition = QuantumCircuit(*self.definition.qregs, *self.definition.cregs)
         inverse_gate.definition._data = [(inst.inverse(), qargs, cargs)


### PR DESCRIPTION
### Summary
Label of the inverse of a gate is now label+'_dg'

### Details and comments
The inverse of a gate obtained by gate.inverse() did not reflect the label of the parent gate, and instead used the 'name' attribute of the gate as its label. Now the inverse of a gate will carry the label of its parent followed by '_dg'.

Previous:
![image](https://user-images.githubusercontent.com/53686844/103279964-2f0b0a80-49f5-11eb-872d-f9837866b9c2.png)

Updated:
![image](https://user-images.githubusercontent.com/53686844/103278761-47c5f100-49f2-11eb-96b4-f79cb41d94cc.png)
