### PR TITLE
Set a seed for random_circuit in nlocal tests (#5599)

### DIFF
--- a/test/python/circuit/library/test_nlocal.py
+++ b/test/python/circuit/library/test_nlocal.py
@@ -96,14 +96,14 @@ class TestNLocal(QiskitTestCase):
         reference = QuantumCircuit(max(num_qubits))
 
         # construct the NLocal from the first circuit
-        first_circuit = random_circuit(num_qubits[0], depth)
+        first_circuit = random_circuit(num_qubits[0], depth, seed=4200)
         # TODO Terra bug: if this is to_gate it fails, since the QC adds an instruction not gate
         nlocal = NLocal(max(num_qubits), entanglement_blocks=first_circuit.to_instruction(), reps=1)
         reference.append(first_circuit, list(range(num_qubits[0])))
 
         # append the rest
         for num in num_qubits[1:]:
-            circuit = random_circuit(num, depth)
+            circuit = random_circuit(num, depth, seed=4200)
             nlocal.append(circuit, list(range(num)))
             reference.append(circuit, list(range(num)))
 
@@ -119,14 +119,14 @@ class TestNLocal(QiskitTestCase):
         reference = QuantumCircuit(max(num_qubits))
 
         # construct the NLocal from the first circuit
-        first_circuit = random_circuit(num_qubits[0], depth)
+        first_circuit = random_circuit(num_qubits[0], depth, seed=4220)
         # TODO Terra bug: if this is to_gate it fails, since the QC adds an instruction not gate
         nlocal = NLocal(max(num_qubits), entanglement_blocks=first_circuit.to_instruction(), reps=1)
         reference.append(first_circuit, list(range(num_qubits[0])))
 
         # append the rest
         for num in num_qubits[1:]:
-            circuit = random_circuit(num, depth)
+            circuit = random_circuit(num, depth, seed=4220)
             nlocal.add_layer(NLocal(num, entanglement_blocks=circuit, reps=1))
             reference.append(circuit, list(range(num)))
 
@@ -138,8 +138,8 @@ class TestNLocal(QiskitTestCase):
         num_qubits, depth = 2, 2
 
         # construct two circuits for adding
-        first_circuit = random_circuit(num_qubits, depth)
-        circuit = random_circuit(num_qubits, depth)
+        first_circuit = random_circuit(num_qubits, depth, seed=4242)
+        circuit = random_circuit(num_qubits, depth, seed=4242)
 
         # get a reference
         reference = first_circuit + circuit


### PR DESCRIPTION
For some of the nlocal tests we are seeing a non-deterministic failure
rate of roughly 1% in CI without any debugging information. An asserted
equality is returning False failing which doesn't tell us how the
circuits differ or offer any indication as to what went wrong.
In local testing we've been un able to reproduce the failure. However,
the test_nlocal module is using the random_circuit() function to
randomly generate a circuit for test purposes and was not setting a
seed which is the only source of randomness in the test path. This means
the output circuit could be a bad input and we're tripping a weird edge
case. To hopefully address the failure mode this commit sets a seed on
all the random_circuit calls in the module to ensure we're always using
the same input.

Attempts to Fix #5217

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


